### PR TITLE
Disable post button when there is no content

### DIFF
--- a/Icro/View/KeyboardInputView.swift
+++ b/Icro/View/KeyboardInputView.swift
@@ -11,8 +11,8 @@ enum ImageState {
     case uploading(progress: Float)
 }
 
-class KeyboardInputView: UIView {
-    var text: String? {
+final class KeyboardInputView: UIView {
+    private var text: String? {
         didSet {
             guard let text = text, text.count > 0 else {
                 characterCountLabel.text = ""
@@ -43,15 +43,17 @@ class KeyboardInputView: UIView {
         linkButton.setTitle(NSLocalizedString("KEYBOARDINPUTVIEW_LINKBUTTON_TTILE", comment: ""), for: .normal)
         imageButton.setTitle(NSLocalizedString("KEYBOARDINPUTVIEW_IMAGEBUTTON_TITLE", comment: ""), for: .normal)
         postButton.setTitle(NSLocalizedString("KEYBOARDINPUTVIEW_POSTBUTTON_TITLE", comment: ""), for: .normal)
-        update(for: .idle)
+        update(for: "", numberOfImages: 0, imageState: .idle)
     }
 
-    func update(for imageState: ImageState) {
+    func update(for text: String, numberOfImages: Int, imageState: ImageState) {
+        self.text = text
+
         switch imageState {
         case .idle:
             cancelButton.isHidden = true
             progressView.isHidden = true
-            postButton.isEnabled = true
+            postButton.isEnabled = text.count > 0 || numberOfImages > 0
             imageButton.isEnabled = true
         case .uploading(let progress):
             postButton.isEnabled = false

--- a/Icro/ViewController/ComposeViewController.swift
+++ b/Icro/ViewController/ComposeViewController.swift
@@ -56,11 +56,18 @@ final class ComposeViewController: UIViewController {
         keyboardInputView.cancelButton.addTarget(self, action: #selector(canelImageUpload), for: .touchUpInside)
 
         viewModel.didUpdateImages = { [weak self] in
-            self?.updateImageCollection()
+            guard let strongSelf = self else { return }
+            strongSelf.updateImageCollection()
+            strongSelf.keyboardInputView.update(for: strongSelf.textView.text,
+                                                numberOfImages: strongSelf.viewModel.numberOfImages,
+                                                imageState: strongSelf.viewModel.imageState)
         }
 
         viewModel.didChangeImageState = { [weak self] imageState in
-            self?.keyboardInputView.update(for: imageState)
+            guard let strongSelf = self else { return }
+            strongSelf.keyboardInputView.update(for: strongSelf.textView.text,
+                                                numberOfImages: strongSelf.viewModel.numberOfImages,
+                                                imageState: strongSelf.viewModel.imageState)
         }
 
         navigationItem.leftBarButtonItem = cancelButton
@@ -93,7 +100,9 @@ final class ComposeViewController: UIViewController {
     // MARK: - Private
 
     private func setupKeyboardInputView() {
-        keyboardInputView.text = viewModel.startText
+        keyboardInputView.update(for: viewModel.startText,
+                                 numberOfImages: viewModel.numberOfImages,
+                                 imageState: viewModel.imageState)
         keyboardInputView.translatesAutoresizingMaskIntoConstraints = false
         keyboardInputView.addConstraint(NSLayoutConstraint(item: keyboardInputView,
                                                            attribute: .height,
@@ -196,7 +205,7 @@ extension ComposeViewController: UITableViewDelegate, UITableViewDataSource {
 
 extension ComposeViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        keyboardInputView.text = textView.text
+        keyboardInputView.update(for: textView.text, numberOfImages: viewModel.numberOfImages, imageState: viewModel.imageState)
     }
 }
 

--- a/Icro/ViewModel/ComposeViewModel.swift
+++ b/Icro/ViewModel/ComposeViewModel.swift
@@ -22,6 +22,12 @@ final class ComposeViewModel {
     private let imageUploadService = MicropubRequestController()
     private let userSettings: UserSettings
 
+    private(set) var imageState = ImageState.idle {
+        didSet {
+            didChangeImageState?(imageState)
+        }
+    }
+
     var didChangeImageState: ((ImageState) -> Void)?
 
     var didUpdateImages: (() -> Void)?
@@ -81,11 +87,11 @@ final class ComposeViewModel {
     }
 
     func upload(image: UIImage) {
-        didChangeImageState?(.uploading(progress: 0.0))
+        imageState = .uploading(progress: 0.0)
         imageUploadService.uploadImages(image: image, uploadProgress: { [weak self] progress in
-            self?.didChangeImageState?(.uploading(progress: progress))
+            self?.imageState = .uploading(progress: progress)
             }, completion: { [weak self] image, _ in
-            self?.didChangeImageState?(.idle)
+            self?.imageState = .idle
 
             if let image = image {
                 self?.insertImage(image: image)
@@ -94,7 +100,7 @@ final class ComposeViewModel {
     }
 
     func cancelImageUpload() {
-        didChangeImageState?(.idle)
+        imageState = .idle
         imageUploadService.cancelImageUpload()
     }
 


### PR DESCRIPTION
## Background
The current version of the app allows you to post even if you haven't typed in any content or uploaded any images. A post isn't actually created on micro.blog.

## Modifications
I created a stored property for the `ImageState` on the `ComposeViewModel`. We need to store this so we can evaluate if the post button should be enabled/disabled based on text length, image uploading status, and also how many images have been uploaded. Please let me know if you think there was a better way to do this.

## Testing
* By default the post button should be disabled when creating a new post.
* If you upload an image the post button should be enabled after it is uploaded.
* If you type in any text it should become enabled. If you delete the text and don't have any images uploaded, it should be disabled.
* If are uploading an image you should be able to type text. The post button shouldn't be enabled because the image is still uploading.

Fixes https://github.com/hartlco/Icro/issues/10