### PR TITLE
Prevent swiping on an Author Cell

### DIFF
--- a/Icro/Configurator/EditActionsConfigurator.swift
+++ b/Icro/Configurator/EditActionsConfigurator.swift
@@ -18,6 +18,15 @@ final class EditActionsConfigurator {
         self.viewModel = viewModel
     }
 
+    func canEdit(at indexPath: IndexPath) -> Bool {
+        switch viewModel.viewType(for: indexPath.section, row: indexPath.row) {
+        case .author:
+            return false
+        case .item:
+            return true
+        }
+    }
+
     func tralingEditActions(at indexPath: IndexPath, in tableView: UITableView) -> UISwipeActionsConfiguration? {
         let item = viewModel.item(for: indexPath.row)
         let cell = tableView.cellForRow(at: indexPath)

--- a/Icro/ViewController/ListViewController.swift
+++ b/Icro/ViewController/ListViewController.swift
@@ -210,6 +210,10 @@ extension ListViewController: UITableViewDataSource, UITableViewDelegate, UITabl
                    leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         return editActionsConfigurator.leadingEditActions(at: indexPath, in: tableView)
     }
+
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return editActionsConfigurator.canEdit(at: indexPath)
+    }
 }
 
 extension ListViewController: ScrollToTop {


### PR DESCRIPTION
## Background
Previous to this PR we were allowing a user to swipe on an Author cell. The user should only be able to swipe on an Item Cell

## Testing
* Ensure that you can swipe on all posts.
* Ensure that you can't swipe on any author cells

Fixes https://github.com/hartlco/Icro/issues/9